### PR TITLE
Re-encodes string from api gateway

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (string
 		"DELETE DATA": true,
 	}
 
-	proxyReq, _ := http.NewRequest("POST", os.Getenv("RIALTO_SPARQL_ENDPOINT"), strings.NewReader(encodeBody(request.Body)))
+	proxyReq, _ := http.NewRequest("POST", os.Getenv("RIALTO_SPARQL_ENDPOINT"), encodeBody(request.Body))
 	proxyReq.Header = make(http.Header)
 
 	proxyReq.Header.Add("Content-type", "application/x-www-form-urlencoded")
@@ -72,14 +72,14 @@ func main() {
 	lambda.Start(Handler)
 }
 
-func encodeBody(bodyIn string) string {
+func encodeBody(bodyIn string) *strings.Reader {
 	// The body that we get from API gateway is decoded, so we need to re-encode it
 	// However, we need to first remove the query/update directive before encoding.
 	i := strings.Index(bodyIn, "=")
 	queryPrefix := bodyIn[:i]
 	bodyIn = bodyIn[i+1:]
 	bodyIn = fmt.Sprintf("%s=%s", queryPrefix, url.QueryEscape(bodyIn))
-	return bodyIn
+	return strings.NewReader(bodyIn)
 }
 
 func uniqueSubjects(in []sparql.Triple) []string {

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (string
 		"DELETE DATA": true,
 	}
 
-	proxyReq, err := http.NewRequest("POST", os.Getenv("RIALTO_SPARQL_ENDPOINT"), strings.NewReader(encodeBody(request.Body)))
+	proxyReq, _ := http.NewRequest("POST", os.Getenv("RIALTO_SPARQL_ENDPOINT"), strings.NewReader(encodeBody(request.Body)))
 	proxyReq.Header = make(http.Header)
 
 	proxyReq.Header.Add("Content-type", "application/x-www-form-urlencoded")


### PR DESCRIPTION
Based on testing we've determined that the string we get from the API Gateway has been decoded and is causing errors when sent through raw to Neptune. We need to re-encode the string we get.