### PR TITLE
Only check that escaping is done when the proper Content-Type is set

### DIFF
--- a/cmd/neptune/main_test.go
+++ b/cmd/neptune/main_test.go
@@ -14,7 +14,7 @@ type MockSparqlWriter struct {
 	mock.Mock
 }
 
-func (f *MockSparqlWriter) Post(query string) (*events.APIGatewayProxyResponse, error) {
+func (f *MockSparqlWriter) Post(query string, contentType string) (*events.APIGatewayProxyResponse, error) {
 	return &events.APIGatewayProxyResponse{StatusCode: 200}, nil
 }
 
@@ -22,7 +22,7 @@ type MockSparqlWriterWithError struct {
 	mock.Mock
 }
 
-func (f *MockSparqlWriterWithError) Post(query string) (*events.APIGatewayProxyResponse, error) {
+func (f *MockSparqlWriterWithError) Post(query string, contentType string) (*events.APIGatewayProxyResponse, error) {
 	return &events.APIGatewayProxyResponse{StatusCode: 400}, nil
 }
 
@@ -42,30 +42,40 @@ func TestHandlerUnit(t *testing.T) {
 	registry := runtime.NewRegistry(new(MockSparqlWriter), new(MockSnsWriter))
 	handler := runtime.NewHandler(registry)
 	var testCases = []struct {
-		file     string
-		out      int
-		msgCount int
+		file        string
+		contentType string
+		out         int
+		msgCount    int
 	}{
 		{
-			file:     "../../fixtures/select_triples.txt",
-			out:      200,
-			msgCount: 0, // This test is a SELECT, so no message should be published
+			file:        "../../fixtures/select_triples.txt",
+			contentType: "application/x-www-form-urlencoded",
+			out:         200,
+			msgCount:    0, // This test is a SELECT, so no message should be published
 		},
 		{
-			file:     "../../fixtures/decoded_query.txt",
-			out:      422,
-			msgCount: 0, // No messages should be published on a bad query
+			file:        "../../fixtures/decoded_query.txt",
+			contentType: "application/x-www-form-urlencoded",
+			out:         422,
+			msgCount:    0, // No messages should be published on a bad query
 		},
 		{
-			file:     "../../fixtures/insert.txt",
-			out:      200,
-			msgCount: 1, // A message should only be added on a successful INSERT
+			file:        "../../fixtures/decoded_query.txt",
+			contentType: "application/sparql-query",
+			out:         200,
+			msgCount:    1,
+		},
+		{
+			file:        "../../fixtures/insert.txt",
+			contentType: "application/x-www-form-urlencoded",
+			out:         200,
+			msgCount:    2, // A message should only be added on a successful INSERT
 		},
 	}
 
 	for _, tt := range testCases {
 		content, _ := ioutil.ReadFile(tt.file)
-		actual, err := handler.RequestHandler(nil, events.APIGatewayProxyRequest{Body: string(content)})
+		actual, err := handler.RequestHandler(nil, events.APIGatewayProxyRequest{Body: string(content), Headers: map[string]string{"Content-Type": tt.contentType}})
 		is.NoErr(err)
 		is.Equal(tt.out, actual.StatusCode)
 		is.Equal(tt.msgCount, len(messages))
@@ -81,5 +91,5 @@ func TestHandlerWithBadQuery(t *testing.T) {
 	actual, err := handler.RequestHandler(nil, events.APIGatewayProxyRequest{Body: string(content)})
 	is.NoErr(err)
 	is.Equal(400, actual.StatusCode)
-	is.Equal(1, len(messages))
+	is.Equal(2, len(messages))
 }

--- a/sparql/neptune_client.go
+++ b/sparql/neptune_client.go
@@ -19,8 +19,8 @@ func NewNeptuneClient(endpoint string) *NeptuneClient {
 }
 
 // Post exposes the POST function to the handler
-func (n *NeptuneClient) Post(query string) (*events.APIGatewayProxyResponse, error) {
-	res, err := n.HTTPProxy(query)
+func (n *NeptuneClient) Post(query string, contentType string) (*events.APIGatewayProxyResponse, error) {
+	res, err := n.HTTPProxy(query, contentType)
 	if err != nil {
 		return nil, err
 	}
@@ -28,10 +28,10 @@ func (n *NeptuneClient) Post(query string) (*events.APIGatewayProxyResponse, err
 }
 
 // HTTPProxy passes any query string directly to the NeptuneClient endpoint
-func (n *NeptuneClient) HTTPProxy(query string) (*events.APIGatewayProxyResponse, error) {
+func (n *NeptuneClient) HTTPProxy(query string, contentType string) (*events.APIGatewayProxyResponse, error) {
 
 	proxyReq, _ := http.NewRequest("POST", n.endpoint, strings.NewReader(query))
-	proxyReq.Header.Set("Content-type", "application/x-www-form-urlencoded")
+	proxyReq.Header.Set("Content-Type", contentType)
 
 	httpClient := http.Client{}
 

--- a/sparql/writer.go
+++ b/sparql/writer.go
@@ -4,5 +4,5 @@ import "github.com/aws/aws-lambda-go/events"
 
 // Writer sends an HTTP Post Request to a SPARQL endpoint
 type Writer interface {
-	Post(query string) (*events.APIGatewayProxyResponse, error)
+	Post(query string, contentType string) (*events.APIGatewayProxyResponse, error)
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -22,30 +22,35 @@ func TestHandlerIntegration(t *testing.T) {
 	registry := runtime.NewRegistry(sparqlClient, snsClient)
 	handler := runtime.NewHandler(registry)
 	var testCases = []struct {
-		file string
-		out  int
+		file        string
+		out         int
+		contentType string
 	}{
 		{
-			file: "../fixtures/select_triples.txt",
-			out:  200,
+			file:        "../fixtures/select_triples.txt",
+			contentType: "application/x-www-form-urlencoded",
+			out:         200,
 		},
 		{
-			file: "../fixtures/decoded_query.txt",
-			out:  422,
+			file:        "../fixtures/decoded_query.txt",
+			contentType: "application/x-www-form-urlencoded",
+			out:         422,
 		},
 		{
-			file: "../fixtures/insert.txt",
-			out:  200,
+			file:        "../fixtures/insert.txt",
+			contentType: "application/x-www-form-urlencoded",
+			out:         200,
 		},
 		{
-			file: "../fixtures/bad_insert.txt",
-			out:  400,
+			file:        "../fixtures/bad_insert.txt",
+			contentType: "application/x-www-form-urlencoded",
+			out:         400,
 		},
 	}
 
 	for _, tt := range testCases {
 		content, _ := ioutil.ReadFile(tt.file)
-		actual, err := handler.RequestHandler(nil, events.APIGatewayProxyRequest{Body: string(content)})
+		actual, err := handler.RequestHandler(nil, events.APIGatewayProxyRequest{Body: string(content), Headers: map[string]string{"Content-Type": tt.contentType}})
 		is.NoErr(err)
 		is.Equal(tt.out, actual.StatusCode)
 	}


### PR DESCRIPTION
See https://www.w3.org/TR/sparql11-protocol/#query-via-post-urlencoded

Fixes sul-dlss/rialto#268