### PR TITLE
Add a log message with the query if parsing is slower than 5 seconds

### DIFF
--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -64,6 +64,9 @@ func (p *ProxyHandler) RequestHandler(ctx context.Context, request events.APIGat
 
 	message := p.formatMessage(request.Body, contentType)
 	log.Printf("SPARQL parse elapsed time: %s", time.Since(start))
+	if time.Since(start).Seconds() > 5 { // Log if the elapsed time is > 5 seconds. TODO: Make this configurable
+		log.Printf("SPARQL Query: \n%s", request.Body)
+	}
 
 	if message != nil {
 		start = time.Now()


### PR DESCRIPTION
This is an initial pass to get the message in the logs. This should eventually be a configurable timeout and a CloudWatch alert.