### PR TITLE
Get the request content-type to pass through to neptune

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -25,16 +25,18 @@ def main(event, _):
     rialto_topic_arn = os.getenv('RIALTO_TOPIC_ARN', "rialto")
     aws_region = os.getenv('AWS_REGION', "us-west-2")
 
+    request_content_type = event['headers']['Content-Type']  # capture this value for use throughout
+
     sns_client = SnsClient(rialto_sns_endpoint, rialto_topic_arn, aws_region)
     neptune_client = NeptuneClient(rialto_sparql_endpoint)
 
     start_time = time.time()
     logger.info("NEPTUNE START: " + time.asctime(time.localtime(start_time)))
-    response, status_code = neptune_client.post(event['body'])
+    response, status_code = neptune_client.post(event['body'], request_content_type)
     logger.info("NEPTUNE ELAPSED: %f" % (time.time() - start_time))
 
     if status_code == 200:
-        if "update=" in event['body'] or event['Content-Type'] == "application/sparql-update":
+        if "update=" in event['body'] or request_content_type == "application/sparql-update":
             start_time = time.time()
             logger.info("SPARQL PARSE START: " + time.asctime(time.localtime(start_time)))
             entities = get_unique_subjects(

--- a/neptune_client.py
+++ b/neptune_client.py
@@ -5,8 +5,8 @@ class NeptuneClient():
     def __init__(self, sparql_endpoint):
         self.sparql_endpoint = sparql_endpoint
 
-    def post(self, request_body):
+    def post(self, request_body, request_content_type):
         response = requests.post(self.sparql_endpoint,
                                  data=request_body,
-                                 headers={"Content-Type": "application/sparql-update"})
+                                 headers={"Content-Type": request_content_type})
         return response.text, response.status_code


### PR DESCRIPTION
This is necessary as we cannot use a hard coded content type that assumes an update if a query is passed through.